### PR TITLE
Work-around crash on missing locale support

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -3,6 +3,9 @@
 # Work-around https://gitlab.gnome.org/GNOME/gnome-build-meta/-/issues/754
 grep -q org.freedesktop.Platform.GL.nvidia /.flatpak-info && export WEBKIT_DISABLE_DMABUF_RENDERER=1
 
+# Work-around https://github.com/bambulab/BambuStudio/issues/3440
+export LC_ALL=C.UTF-8
+
 if [ $BAMBU_STUDIO_DARK_THEME == true ]; then
     export GTK_THEME='Adwaita:dark'
     # echo "Message: $(date +%T): INFO: using dark theme variant"


### PR DESCRIPTION
BambuStudio crashes when running under an unsupported locale: https://github.com/bambulab/BambuStudio/issues/3440

Force `C-UTF-8` as the locale, seeing as the UI doesn't follow the OS locale for its UI and expects users to change the language on first start or in the preferences.