### PR TITLE
Fix Octoprint failure

### DIFF
--- a/com.bambulab.BambuStudio.yml
+++ b/com.bambulab.BambuStudio.yml
@@ -311,6 +311,9 @@ modules:
       - type: patch
         path: patches/0001-Work-around-ClipperLib-union_-declaration-problem.patch
 
+      - type: patch
+        path: patches/0001-FIX-fix-the-compiling-error-under-macos-for-previous.patch
+
       # Use system deps instead of building them within BambuStudio
       # https://github.com/hadess/BambuStudio/tree/wip/hadess/use-sysdeps
       - type: patch

--- a/patches/0001-FIX-fix-the-compiling-error-under-macos-for-previous.patch
+++ b/patches/0001-FIX-fix-the-compiling-error-under-macos-for-previous.patch
@@ -1,0 +1,33 @@
+From 9b47f26f20ce938a531be59742e5c1c4908ee245 Mon Sep 17 00:00:00 2001
+From: "lane.wei" <lane.wei@bambulab.com>
+Date: Fri, 19 Jan 2024 17:49:22 +0800
+Subject: [PATCH] FIX: fix the compiling error under macos for previous patches
+
+/Users/ci.slave/slicer/patch_build/1/bamboo_slicer/src/libslic3r/GCode/GCodeProcessor.cpp:486:33: error: cannot pass non-trivial object of type 'std::string' (aka 'basic_string<char, char_traits<char>, allocator<char>>') to variadic function; expected type from format string was 'char *' [-Wnon-pod-varargs]
+                                  get_time_dhms(machine.time));
+                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+github pull request: https://github.com/bambulab/BambuStudio/pull/3360
+Change-Id: If13ee145b20ef9532b23a58bb3b0a29f30d8c0a8
+
+Change-Id: I98fd87417c432c3afae67a3d2bc29c79f8bffa3c
+---
+ src/libslic3r/GCode/GCodeProcessor.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/libslic3r/GCode/GCodeProcessor.cpp b/src/libslic3r/GCode/GCodeProcessor.cpp
+index a0431dcd5f54..1dae839a27c1 100644
+--- a/src/libslic3r/GCode/GCodeProcessor.cpp
++++ b/src/libslic3r/GCode/GCodeProcessor.cpp
+@@ -483,7 +483,7 @@ void GCodeProcessor::TimeProcessor::post_process(const std::string& filename, st
+                         if (!s_IsBBLPrinter) {
+                             // Klipper estimator
+                             sprintf(buf, "; estimated printing time (normal mode) = %s\n",
+-                                get_time_dhms(machine.time));
++                                get_time_dhms(machine.time).c_str());
+                             ret += buf;
+                         } else {
+                             // BBS estimator
+-- 
+2.43.0
+


### PR DESCRIPTION
Fix non-ASCII characters showing up in non-BambuLab GCode, causing Octoprint to fail.

Closes: #7