### PR TITLE
Adding patch for klipper estimation

### DIFF
--- a/com.bambulab.BambuStudio.yml
+++ b/com.bambulab.BambuStudio.yml
@@ -316,6 +316,10 @@ modules:
       - type: patch
         path: patches/use-sysdeps.patch
 
+      # Correction for klipper print estimation
+      - type: patch
+        path: patches/0008-correct-klipper-estimator.patch
+
       # AppData metainfo for Gnome Software & Co.
       - type: file
         path: com.bambulab.BambuStudio.metainfo.xml

--- a/patches/0008-correct-klipper-estimator.patch
+++ b/patches/0008-correct-klipper-estimator.patch
@@ -1,0 +1,13 @@
+diff --git a/src/libslic3r/GCode/GCodeProcessor.cpp b/src/libslic3r/GCode/GCodeProcessor.cpp
+index a0431dcd..1dae839a 100644
+--- a/src/libslic3r/GCode/GCodeProcessor.cpp
++++ b/src/libslic3r/GCode/GCodeProcessor.cpp
+@@ -483,7 +483,7 @@ void GCodeProcessor::TimeProcessor::post_process(const std::string& filename, st
+                         if (!s_IsBBLPrinter) {
+                             // Klipper estimator
+                             sprintf(buf, "; estimated printing time (normal mode) = %s\n",
+-                                get_time_dhms(machine.time));
++                                get_time_dhms(machine.time).c_str());
+                             ret += buf;
+                         } else {
+                             // BBS estimator


### PR DESCRIPTION
Correct a bug in the klipper estimator during gcode processing.


The bug has been corrected upstream but not in the flatpak yet : 
https://github.com/bambulab/BambuStudio/blame/master/src/libslic3r/GCode/GCodeProcessor.cpp#L486

In the meantime, this PR correct the issue