### PR TITLE
Downgrade wxWidgets to 3.1.5

### DIFF
--- a/com.bambulab.BambuStudio.yml
+++ b/com.bambulab.BambuStudio.yml
@@ -157,11 +157,17 @@ modules:
       - -DwxUSE_EXPAT=sys
     sources:
       - type: archive
-        url: https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.4/wxWidgets-3.2.4.tar.bz2
-        sha256: 0640e1ab716db5af2ecb7389dbef6138d7679261fbff730d23845ba838ca133e
+        url: https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.5/wxWidgets-3.1.5.tar.bz2
+        sha256: d7b3666de33aa5c10ea41bb9405c40326e1aeb74ee725bb88f90f1d50270a224
       # https://github.com/bambulab/BambuStudio/issues/3279
       - type: patch
         path: patches/disable-gstplayer.patch
+      # https://github.com/wxWidgets/wxWidgets/issues/23630
+      - type: patch
+        path: patches/0001-Add-support-for-building-WebView-with-libwebkit2gtk-.patch
+      # wx-config/build fixes between 3.1.5 and 3.1.6
+      - type: patch
+        path: patches/wxwidgets-not-found.patch
     cleanup:
       - /include
       - /lib/cmake

--- a/patches/0001-Add-support-for-building-WebView-with-libwebkit2gtk-.patch
+++ b/patches/0001-Add-support-for-building-WebView-with-libwebkit2gtk-.patch
@@ -1,0 +1,167 @@
+From df46add1165314bce93d70e611ddc453561ffb60 Mon Sep 17 00:00:00 2001
+From: Scott Talbert <swt@techie.net>
+Date: Mon, 12 Jun 2023 20:28:35 -0400
+Subject: [PATCH] Add support for building WebView with libwebkit2gtk-4.1
+
+libwebkit2gtk-4.1 has the same API as libwebkit2gtk-4.0, except that the
+former links with libsoup-3.0 and the latter links with libsoup-2.4.
+
+Fixes #23630.
+
+(cherry picked from commit 1b8664426603376b68f8ca3c54de97ec630e5940)
+---
+ build/cmake/init.cmake                | 10 ++-
+ build/cmake/modules/FindLIBSOUP.cmake | 14 +++-
+ build/cmake/modules/FindWEBKIT2.cmake |  5 +-
+ configure                             | 95 +++++++++++++++++++++++++--
+ configure.in                          | 16 ++++-
+ src/gtk/webview_webkit2.cpp           |  4 ++
+ 6 files changed, 129 insertions(+), 15 deletions(-)
+
+diff --git a/build/cmake/init.cmake b/build/cmake/init.cmake
+index fc206cf2e03a..5d88a7e487cc 100644
+--- a/build/cmake/init.cmake
++++ b/build/cmake/init.cmake
+@@ -453,15 +453,21 @@ if(wxUSE_GUI)
+     if(wxUSE_WEBVIEW)
+         if(WXGTK)
+             if(wxUSE_WEBVIEW_WEBKIT)
+-                find_package(LIBSOUP)
++                set(WEBKIT_LIBSOUP_VERSION 2.4)
+                 if(WXGTK2)
+                     find_package(WEBKIT 1.0)
+                 elseif(WXGTK3)
+-                    find_package(WEBKIT2)
++                    find_package(WEBKIT2 4.1 QUIET)
++                    if(WEBKIT2_FOUND)
++                        set(WEBKIT_LIBSOUP_VERSION 3.0)
++                    else()
++                        find_package(WEBKIT2 4.0)
++                    endif()
+                     if(NOT WEBKIT2_FOUND)
+                         find_package(WEBKIT 3.0)
+                     endif()
+                 endif()
++                find_package(LIBSOUP ${WEBKIT_LIBSOUP_VERSION})
+             endif()
+             set(wxUSE_WEBVIEW_WEBKIT OFF)
+             set(wxUSE_WEBVIEW_WEBKIT2 OFF)
+diff --git a/build/cmake/modules/FindLIBSOUP.cmake b/build/cmake/modules/FindLIBSOUP.cmake
+index cbfba1cf9366..2433d141eaf7 100644
+--- a/build/cmake/modules/FindLIBSOUP.cmake
++++ b/build/cmake/modules/FindLIBSOUP.cmake
+@@ -31,19 +31,27 @@
+ # LibSoup does not provide an easy way to retrieve its version other than its
+ # .pc file, so we need to rely on PC_LIBSOUP_VERSION and REQUIRE the .pc file
+ # to be found.
++SET(LIBSOUP_VERSION 2.4)
++if(DEFINED LIBSOUP_FIND_VERSION)
++    SET(LIBSOUP_VERSION ${LIBSOUP_FIND_VERSION})
++endif()
++
++set(LIBSOUP_INCLUDE_DIRS LIBSOUP_INCLUDE_DIRS-NOTFOUND)
++set(LIBSOUP_LIBRARIES LIBSOUP_LIBRARIES-NOTFOUND)
++
+ FIND_PACKAGE(PkgConfig)
+-PKG_CHECK_MODULES(PC_LIBSOUP QUIET libsoup-2.4)
++PKG_CHECK_MODULES(PC_LIBSOUP QUIET libsoup-${LIBSOUP_VERSION})
+ 
+ if(PC_LIBSOUP_FOUND)
+     FIND_PATH(LIBSOUP_INCLUDE_DIRS
+         NAMES libsoup/soup.h
+         HINTS ${PC_LIBSOUP_INCLUDEDIR}
+         ${PC_LIBSOUP_INCLUDE_DIRS}
+-        PATH_SUFFIXES libsoup-2.4
++        PATH_SUFFIXES libsoup-${LIBSOUP_VERSION}
+         )
+ 
+     FIND_LIBRARY(LIBSOUP_LIBRARIES
+-        NAMES soup-2.4
++        NAMES soup-${LIBSOUP_VERSION}
+         HINTS ${PC_LIBSOUP_LIBDIR}
+         ${PC_LIBSOUP_LIBRARY_DIRS}
+         )
+diff --git a/build/cmake/modules/FindWEBKIT2.cmake b/build/cmake/modules/FindWEBKIT2.cmake
+index 133e7a4563ea..e39077ac4a71 100644
+--- a/build/cmake/modules/FindWEBKIT2.cmake
++++ b/build/cmake/modules/FindWEBKIT2.cmake
+@@ -5,7 +5,10 @@
+ #  WEBKIT2_LIBRARIES   - List of libraries when using Webkit2.
+ #  WEBKIT2_FOUND       - True if Webkit2 found.
+ 
+-SET( WEBKIT2_VERSION 4.0)
++SET(WEBKIT2_VERSION 4.0)
++if(DEFINED WEBKIT2_FIND_VERSION)
++    SET(WEBKIT2_VERSION ${WEBKIT2_FIND_VERSION})
++endif()
+ 
+ set(WEBKIT2_INCLUDE_DIR WEBKIT2_INCLUDE_DIR-NOTFOUND)
+ set(WEBKIT2_LIBRARY WEBKIT2_LIBRARY-NOTFOUND)
+diff --git a/configure.in b/configure.in
+index 957be8dda34c..257c95a6009b 100644
+--- a/configure.in
++++ b/configure.in
+@@ -7529,15 +7529,27 @@ if test "$wxUSE_WEBVIEW" = "yes"; then
+         if test "$wxUSE_GTK" = 1; then
+             if test "$WXGTK3" = 1; then
+                 PKG_CHECK_MODULES([WEBKIT],
+-                                  [webkit2gtk-4.0],
++                                  [webkit2gtk-4.1],
+                                   [
+                                     USE_WEBVIEW_WEBKIT2=1
+                                     CXXFLAGS="$CXXFLAGS $WEBKIT_CFLAGS"
+                                     EXTRALIBS_WEBVIEW="$WEBKIT_LIBS"
+                                   ],
+                                   [
+-                                    AC_MSG_WARN([webkit2gtk not found, falling back to webkitgtk])
++                                    AC_MSG_WARN([webkit2gtk-4.1 not found, falling back to webkit2gtk-4.0])
+                                   ])
++                if test "$USE_WEBVIEW_WEBKIT2" = 0; then
++                    PKG_CHECK_MODULES([WEBKIT],
++                                      [webkit2gtk-4.0],
++                                      [
++                                        USE_WEBVIEW_WEBKIT2=1
++                                        CXXFLAGS="$CXXFLAGS $WEBKIT_CFLAGS"
++                                        EXTRALIBS_WEBVIEW="$WEBKIT_LIBS"
++                                      ],
++                                      [
++                                        AC_MSG_WARN([webkit2gtk-4.0 not found, falling back to webkitgtk])
++                                      ])
++                fi
+             fi
+             if test "$USE_WEBVIEW_WEBKIT2" = 0; then
+                 webkitgtk=webkit-1.0
+diff --git a/src/gtk/webview_webkit2.cpp b/src/gtk/webview_webkit2.cpp
+index 191cbcf2cc18..87a9bd5ad3a8 100644
+--- a/src/gtk/webview_webkit2.cpp
++++ b/src/gtk/webview_webkit2.cpp
+@@ -173,15 +173,18 @@ wxgtk_webview_webkit_load_failed(WebKitWebView *,
+     {
+         switch (error->code)
+         {
++#if SOUP_MAJOR_VERSION < 3
+             case SOUP_STATUS_CANCELLED:
+                 type = wxWEBVIEW_NAV_ERR_USER_CANCELLED;
+                 break;
+ 
+             case SOUP_STATUS_CANT_RESOLVE:
++#endif
+             case SOUP_STATUS_NOT_FOUND:
+                 type = wxWEBVIEW_NAV_ERR_NOT_FOUND;
+                 break;
+ 
++#if SOUP_MAJOR_VERSION < 3
+             case SOUP_STATUS_CANT_RESOLVE_PROXY:
+             case SOUP_STATUS_CANT_CONNECT:
+             case SOUP_STATUS_CANT_CONNECT_PROXY:
+@@ -193,6 +196,7 @@ wxgtk_webview_webkit_load_failed(WebKitWebView *,
+             case SOUP_STATUS_MALFORMED:
+                 type = wxWEBVIEW_NAV_ERR_REQUEST;
+                 break;
++#endif
+ 
+             case SOUP_STATUS_BAD_REQUEST:
+                 type = wxWEBVIEW_NAV_ERR_REQUEST;
+-- 
+2.43.0
+

--- a/patches/wxwidgets-not-found.patch
+++ b/patches/wxwidgets-not-found.patch
@@ -1,0 +1,166 @@
+From 28f59e8900c3a54d4fe6bce43f62d1c4b0070e2c Mon Sep 17 00:00:00 2001
+From: Scott Talbert <swt@techie.net>
+Date: Mon, 11 Oct 2021 12:43:52 -0400
+Subject: [PATCH] cmake: also link with GLU when using EGL
+
+Fixes #19282
+---
+ build/cmake/init.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/build/cmake/init.cmake b/build/cmake/init.cmake
+index e1426afd428f..d5ecda9c98de 100644
+--- a/build/cmake/init.cmake
++++ b/build/cmake/init.cmake
+@@ -411,7 +411,7 @@ if(wxUSE_GUI)
+         else()
+             find_package(OpenGL)
+             if(WXGTK3 AND OpenGL_EGL_FOUND AND wxUSE_GLCANVAS_EGL)
+-                set(OPENGL_LIBRARIES OpenGL::OpenGL OpenGL::EGL)
++                set(OPENGL_LIBRARIES OpenGL::OpenGL OpenGL::GLU OpenGL::EGL)
+                 find_package(WAYLANDEGL)
+                 if(WAYLANDEGL_FOUND AND wxHAVE_GDK_WAYLAND)
+                     list(APPEND OPENGL_LIBRARIES ${WAYLANDEGL_LIBRARIES})
+-- 
+2.43.0
+
+From 0d6485797e23b5df5dded689fd63c86e3149abc9 Mon Sep 17 00:00:00 2001
+From: Maarten Bent <MaartenBent@users.noreply.github.com>
+Date: Thu, 29 Apr 2021 21:39:15 +0200
+Subject: [PATCH 1/4] CMake: don't define WXUSINGDLL in wx-config for static
+ library
+
+---
+ build/cmake/config.cmake | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/build/cmake/config.cmake b/build/cmake/config.cmake
+index 91d11acba206..98b505cbef28 100644
+--- a/build/cmake/config.cmake
++++ b/build/cmake/config.cmake
+@@ -153,10 +153,14 @@ function(wx_write_config)
+         set(WXCONFIG_CFLAGS "-pthread")
+         set(WXCONFIG_LDFLAGS "-pthread")
+     endif()
+-    set(WXCONFIG_CPPFLAGS "-DWXUSINGDLL")
++    set(WXCONFIG_CPPFLAGS)
++    if(wxBUILD_SHARED)
++        wx_string_append(WXCONFIG_CPPFLAGS " -DWXUSINGDLL")
++    endif()
+     foreach(flag IN LISTS wxTOOLKIT_DEFINITIONS)
+         wx_string_append(WXCONFIG_CPPFLAGS " -D${flag}")
+     endforeach()
++    string(STRIP "${WXCONFIG_CPPFLAGS}" WXCONFIG_CPPFLAGS)
+     set(WXCONFIG_CXXFLAGS ${WXCONFIG_CFLAGS})
+     set(WXCONFIG_LDFLAGS_GUI)
+     set(WXCONFIG_RESFLAGS)
+-- 
+2.43.0
+
+
+From ea6049598d806023cd7157600942ed78b719b74f Mon Sep 17 00:00:00 2001
+From: Maarten Bent <MaartenBent@users.noreply.github.com>
+Date: Thu, 29 Apr 2021 21:41:06 +0200
+Subject: [PATCH 2/4] CMake: add '-l' prefix to all library dependencies
+
+---
+ build/cmake/config.cmake | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/build/cmake/config.cmake b/build/cmake/config.cmake
+index 98b505cbef28..d5ec8cf4fbad 100644
+--- a/build/cmake/config.cmake
++++ b/build/cmake/config.cmake
+@@ -39,11 +39,10 @@ macro(wx_get_dependencies var lib)
+                 else()
+                     get_target_property(dep_name ${dep} OUTPUT_NAME)
+                 endif()
+-                set(dep_name "-l${dep_name}")
+             else()
+                 get_filename_component(dep_name ${dep} NAME)
+             endif()
+-            wx_string_append(${var} "${dep_name} ")
++            wx_string_append(${var} "-l${dep_name} ")
+         endforeach()
+         string(STRIP ${${var}} ${var})
+     endif()
+-- 
+2.43.0
+
+
+From 4fae03bdd774b65211d6515104305d1993179eb3 Mon Sep 17 00:00:00 2001
+From: Maarten Bent <MaartenBent@users.noreply.github.com>
+Date: Tue, 4 May 2021 21:30:29 +0200
+Subject: [PATCH 3/4] CMake: Improve adding external libraries to wx-config
+
+Don't add -l to libraries already containing it (for example -lpthread).
+Change libraries with format libName.so or libName.a to -lName,
+configure also uses -l for these libraries. Account for possible invalid
+libraries (Name-NOTFOUND) which could happen with imported libraries,
+for example OpenGL::OpenGL.
+
+Closes https://github.com/wxWidgets/wxWidgets/pull/2359
+---
+ build/cmake/config.cmake | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/build/cmake/config.cmake b/build/cmake/config.cmake
+index d5ec8cf4fbad..c2aa026ef059 100644
+--- a/build/cmake/config.cmake
++++ b/build/cmake/config.cmake
+@@ -42,7 +42,13 @@ macro(wx_get_dependencies var lib)
+             else()
+                 get_filename_component(dep_name ${dep} NAME)
+             endif()
+-            wx_string_append(${var} "-l${dep_name} ")
++            if(dep_name MATCHES "^-l(.*)" OR  dep_name STREQUAL "libc.so")
++                wx_string_append(${var} "${dep_name} ")
++            elseif(dep_name MATCHES "^lib(.*)(.so|.a)")
++                wx_string_append(${var} "-l${CMAKE_MATCH_1} ")
++            elseif(dep_name)
++                wx_string_append(${var} "-l${dep_name} ")
++            endif()
+         endforeach()
+         string(STRIP ${${var}} ${var})
+     endif()
+-- 
+2.43.0
+
+
+From 8455b3a48baf73e91f34ac9301642832aec9b544 Mon Sep 17 00:00:00 2001
+From: Vadim Zeitlin <vadim@wxwidgets.org>
+Date: Wed, 25 Aug 2021 23:31:45 +0200
+Subject: [PATCH 4/4] Fix wx-config --libs output for static monolithic build
+
+Include all extra libraries we need (except for OpenGL ones, as there is
+still a separate library for it, even in monolithic build) in wx-config
+--libs output for static monolithic build as the application (may) need
+all of them, as all the libraries are part of the single monolithic one
+in this case.
+
+It seems that we had an attempt to fix this as far back as in 5719eab2bf
+(Fix missing 3rd party builtin libs for static monolithic builds.,
+2006-09-17), but it was insufficient as it didn't take the dependencies
+of the other GUI libraries (e.g. "media") into account.
+
+Closes #19175.
+---
+ wx-config.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/wx-config.in b/wx-config.in
+index 441f88ce9203..e3f7d115bbbd 100755
+--- a/wx-config.in
++++ b/wx-config.in
+@@ -1218,7 +1218,7 @@ if is_monolithic; then
+         # We still need the core lib deps for a static build though
+         if is_static; then
+             link_deps="${libdir}/libwx_@TOOLCHAIN_NAME@.a"
+-            wx_libs="$wx_libs $link_deps $ldlibs_core $ldlibs_base"
++            wx_libs="$wx_libs $link_deps $ldlibs_html $ldlibs_media $ldlibs_stc $ldlibs_webview $ldlibs_core $ldlibs_xml $ldlibs_base"
+         else
+             wx_libs="$wx_libs -lwx_@TOOLCHAIN_NAME@"
+         fi
+-- 
+2.43.0
+


### PR DESCRIPTION
wxWidgets 3.1.5 is the version of wxWidgets that BambuStudio lists in its builtin dependencies, and is the latest version of wxWidgets that doesn't cause the empty "Flushing Volumes" dialogue that users saw with version 3.2.4.

Note that we had to backport a number of fixes to make the build possible, including:
- upgrade to libwebkit2gtk-4.1 and libsoup-3.0
- fix -ldep_name=NOT-FOUND error in wx-config

Closes: #1