### PR TITLE
Remove unused GStreamer plugins and patches

### DIFF
--- a/com.bambulab.BambuStudio.yml
+++ b/com.bambulab.BambuStudio.yml
@@ -22,20 +22,6 @@ finish-args:
 
 modules:
 
-  # JPEG codec for the liveview
-  - name: gst-plugins-good
-    buildsystem: meson
-    config-opts:
-      - -Dauto_features=disabled
-      - -Djpeg=enabled
-      - -Ddoc=disabled
-      - -Dexamples=disabled
-      - -Dtests=disabled
-    sources:
-      - type: archive
-        url: https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-1.22.8.tar.xz
-        sha256: e305b9f07f52743ca481da0a4e0c76c35efd60adaf1b0694eb3bb021e2137e39
-
   # For libOSMesa
   - name: mesa
     buildsystem: meson
@@ -137,9 +123,6 @@ modules:
       - type: archive
         url: https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.5/wxWidgets-3.1.5.tar.bz2
         sha256: d7b3666de33aa5c10ea41bb9405c40326e1aeb74ee725bb88f90f1d50270a224
-      # https://github.com/bambulab/BambuStudio/issues/3279
-      - type: patch
-        path: patches/disable-gstplayer.patch
       # https://github.com/wxWidgets/wxWidgets/issues/23630
       - type: patch
         path: patches/0001-Add-support-for-building-WebView-with-libwebkit2gtk-.patch


### PR DESCRIPTION
Bambu Studio 1.10.0 started using ffmpeg to playback video.