### PR TITLE
Work-around broken network plugin

### DIFF
--- a/com.bambulab.BambuStudio.yml
+++ b/com.bambulab.BambuStudio.yml
@@ -15,6 +15,8 @@ finish-args:
   - --filesystem=/run/media
   - --filesystem=/media
   - --system-talk-name=org.freedesktop.UDisks2
+  # Work-around https://github.com/bambulab/BambuStudio/issues/6013
+  - --env=SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 
 modules:
 

--- a/com.bambulab.BambuStudio.yml
+++ b/com.bambulab.BambuStudio.yml
@@ -15,8 +15,6 @@ finish-args:
   - --filesystem=/run/media
   - --filesystem=/media
   - --system-talk-name=org.freedesktop.UDisks2
-  # set dark theme
-  - --env=BAMBU_STUDIO_DARK_THEME=false
 
 modules:
 


### PR DESCRIPTION
Work-around the proprietary network plugin not knowing where to load its
certificates from.

See https://github.com/bambulab/BambuStudio/issues/6013
