### PR TITLE
Add VCS browser URL type

### DIFF
--- a/com.bambulab.BambuStudio.metainfo.xml
+++ b/com.bambulab.BambuStudio.metainfo.xml
@@ -11,6 +11,7 @@
     <url type="homepage">https://bambulab.com/en/download/studio</url>
     <url type="help">https://wiki.bambulab.com/en/software</url>
     <url type="bugtracker">https://github.com/bambulab/BambuStudio/issues/</url>
+    <url type="vcs-browser">https://github.com/bambulab/BambuStudio/</url>
     <url type="donation">https://ko-fi.com/hadessuk</url>
     <metadata_license>0BSD</metadata_license>
     <project_license>AGPL-3.0-only</project_license>


### PR DESCRIPTION
As recently added to appstream:
https://github.com/ximion/appstream/pull/392
and soon required by Flathub:
```
'appstream-missing-vcs-browser-url' warning found in linter repo check. Details: Please consider adding a vcs-browser URL to the Metainfo file
```