### PR TITLE
Update runtime to GNOME 50

### DIFF
--- a/com.bambulab.BambuStudio.yml
+++ b/com.bambulab.BambuStudio.yml
@@ -122,6 +122,29 @@ modules:
       - /include
       - /lib/cmake
 
+  - name: blosc
+    buildsystem: cmake-ninja
+    build-options:
+      env:
+        CMAKE_POLICY_VERSION_MINIMUM: '3.5'
+    config-opts:
+      - -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+      - -DBUILD_SHARED=BOOL:OFF
+      - -DBUILD_STATIC=BOOL:ON
+      - -DBUILD_TESTS=OFF
+      - -DBUILD_BENCHMARKS=OFF
+      - -DPREFER_EXTERNAL_ZLIB=ON
+    sources:
+      - type: archive
+        url: https://github.com/tamasmeszaros/c-blosc/archive/refs/heads/v1.17.0_tm.zip
+        sha256: dcb48bf43a672fa3de6a4b1de2c4c238709dad5893d1e097b8374ad84b1fc3b3
+      # https://github.com/Blosc/c-blosc/pull/392
+      - type: patch
+        path: patches/blosc-bool-fix.patch
+    cleanup:
+      - /include
+      - /lib/cmake
+
   - name: BambuStudio
     buildsystem: simple
     build-commands:
@@ -138,7 +161,8 @@ modules:
           -DDEP_BUILD_OPENSSL=OFF \
           -DDEP_BUILD_GLFW=OFF \
           -DDEP_BUILD_FREETYPE=OFF \
-          -DDEP_BUILD_WXWIDGETS=OFF
+          -DDEP_BUILD_WXWIDGETS=OFF \
+          -DDEP_BUILD_BLOSC=OFF
         cmake --build . --target dep_TBB dep_Cereal dep_NLopt dep_libnoise dep_OpenVDB dep_Qhull dep_OpenCSG dep_OpenCV dep_CGAL dep_OCCT
       - |
         mkdir -p build && cd build
@@ -179,12 +203,6 @@ modules:
       #
       # NOTE: The url, dest folder name and sha256 must match from BambuStudio's cmake scripts and folder names in BambuStudio/deps/
       # -
-
-      # Blosc
-      - type: file
-        url: https://github.com/tamasmeszaros/c-blosc/archive/refs/heads/v1.17.0_tm.zip
-        dest: external-packages/Blosc
-        sha256: dcb48bf43a672fa3de6a4b1de2c4c238709dad5893d1e097b8374ad84b1fc3b3
 
       # Cereal
       - type: file
@@ -273,6 +291,10 @@ modules:
       # https://github.com/bambulab/BambuStudio/pull/10213
       - type: patch
         path: patches/2.5.3-fixes.patch
+
+      # https://github.com/bambulab/BambuStudio/pull/10224
+      - type: patch
+        path: patches/0001-ENH-Allow-using-system-Blosc.patch
 
       # Patched TBB cmake to make build without lto flag
       - type: file

--- a/com.bambulab.BambuStudio.yml
+++ b/com.bambulab.BambuStudio.yml
@@ -1,6 +1,6 @@
 app-id: com.bambulab.BambuStudio
 runtime: org.gnome.Platform
-runtime-version: "48"
+runtime-version: "50"
 sdk: org.gnome.Sdk
 command: entrypoint
 rename-icon: BambuStudio
@@ -147,6 +147,9 @@ modules:
 
   - name: BambuStudio
     buildsystem: simple
+    build-options:
+      env:
+        CMAKE_POLICY_VERSION_MINIMUM: '3.5'
     build-commands:
       # start build
       - |
@@ -295,6 +298,10 @@ modules:
       # https://github.com/bambulab/BambuStudio/pull/10224
       - type: patch
         path: patches/0001-ENH-Allow-using-system-Blosc.patch
+
+      # https://github.com/bambulab/BambuStudio/pull/10217
+      - type: patch
+        path: patches/gmp-fixes.patch
 
       # Patched TBB cmake to make build without lto flag
       - type: file

--- a/patches/0001-ENH-Allow-using-system-Blosc.patch
+++ b/patches/0001-ENH-Allow-using-system-Blosc.patch
@@ -1,0 +1,53 @@
+From 42575b11f856bfd4fee72381323f1317818e7dff Mon Sep 17 00:00:00 2001
+From: Bastien Nocera <hadess@hadess.net>
+Date: Thu, 16 Apr 2026 00:37:57 +0200
+Subject: [PATCH] ENH: Allow using system Blosc
+
+To make it easier to test newer versions, or apply system specific
+patches.
+---
+ deps/CMakeLists.txt        | 7 ++++++-
+ deps/OpenVDB/OpenVDB.cmake | 2 +-
+ 2 files changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/deps/CMakeLists.txt b/deps/CMakeLists.txt
+index ec7bdff7b296..503de6fc4fea 100644
+--- a/deps/CMakeLists.txt
++++ b/deps/CMakeLists.txt
+@@ -40,6 +40,7 @@ option(DEP_BUILD_TIFF "Compile libtiff" ON)
+ option(DEP_BUILD_BOOST "Compile boost" ON)
+ option(DEP_BUILD_OPENSSL "Compile openssl" ON)
+ option(DEP_BUILD_GLFW "Compile GLFW" ON)
++option(DEP_BUILD_BLOSC "Compile Blosc" ON)
+ option(DEP_BUILD_FREETYPE "Compile freetype" ON)
+ option(DEP_BUILD_WXWIDGETS "Compile wxWidgets" ON)
+ option(DEP_BUILD_FFMPEG "Compile ffmpeg" ON)
+@@ -241,7 +242,11 @@ include(OpenCSG/OpenCSG.cmake)
+ 
+ include(TBB/TBB.cmake)
+ 
+-include(Blosc/Blosc.cmake)
++set(BLOSC_PKG "")
++if (DEP_BUILD_BLOSC)
++    include(Blosc/Blosc.cmake)
++    set(BLOSC_PKG dep_Blosc)
++endif ()
+ include(OpenEXR/OpenEXR.cmake)
+ include(OpenVDB/OpenVDB.cmake)
+ 
+diff --git a/deps/OpenVDB/OpenVDB.cmake b/deps/OpenVDB/OpenVDB.cmake
+index a5f66c8770d5..e6816a98a8e9 100644
+--- a/deps/OpenVDB/OpenVDB.cmake
++++ b/deps/OpenVDB/OpenVDB.cmake
+@@ -22,7 +22,7 @@ bambustudio_add_cmake_project(OpenVDB
+     PATCH_COMMAND git apply ${OPENVDB_DIRECTORY_FLAG} --verbose --ignore-space-change --whitespace=fix ${CMAKE_CURRENT_LIST_DIR}/0001-clang19.patch
+     # URL https://github.com/AcademySoftwareFoundation/openvdb/archive/refs/tags/v10.0.1.zip
+     # URL_HASH SHA256=48C2CFA9853B58FA86282DF1F83F0E99D07858CC03EB2BA8227DC447A830100A
+-    DEPENDS dep_TBB dep_Blosc dep_OpenEXR ${BOOST_PKG}
++    DEPENDS dep_TBB ${BLOSC_PKG} dep_OpenEXR ${BOOST_PKG}
+     CMAKE_ARGS
+         -DCMAKE_POSITION_INDEPENDENT_CODE=ON 
+         -DOPENVDB_BUILD_PYTHON_MODULE=OFF
+-- 
+2.53.0
+

--- a/patches/blosc-bool-fix.patch
+++ b/patches/blosc-bool-fix.patch
@@ -1,0 +1,42 @@
+From 774f6a0ebaa0c617f7f13ccf6bc89d17eba04654 Mon Sep 17 00:00:00 2001
+From: Georg Semmler <georg.semmler@giga-infosystems.com>
+Date: Thu, 17 Apr 2025 10:19:25 +0200
+Subject: [PATCH] Drop a slightly outdated type def for boolean type
+
+This cases compilation errors with gcc 15 with the following error
+message:
+
+c-blosc/blosc/shuffle.c:26:15: error: 'bool' cannot be defined via 'typedef'
+      | typedef _Bool bool;
+      |               ^~~~
+c-blosc/blosc/shuffle.c:26:15: note: 'bool' is a keyword with '-std=c23' onwards
+
+See https://gcc.gnu.org/gcc-15/porting_to.html for details
+
+I've choosen to remove the typedef as it seems to be unused in this
+file.
+---
+ blosc/shuffle.c | 10 ----------
+ 1 file changed, 10 deletions(-)
+
+diff --git a/blosc/shuffle.c b/blosc/shuffle.c
+index e680a173..9e3ee3e3 100644
+--- a/blosc/shuffle.c
++++ b/blosc/shuffle.c
+@@ -20,16 +20,6 @@
+ #include <pthread.h>
+ #endif
+ 
+-/* Visual Studio < 2013 does not have stdbool.h so here it is a replacement: */
+-#if defined __STDC__ && defined __STDC_VERSION__ && __STDC_VERSION__ >= 199901L
+-/* have a C99 compiler */
+-typedef _Bool bool;
+-#else
+-/* do not have a C99 compiler */
+-typedef unsigned char bool;
+-#endif
+-
+-
+ #if !defined(__clang__) && defined(__GNUC__) && defined(__GNUC_MINOR__) && \
+     __GNUC__ >= 5 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)
+ #define HAVE_CPU_FEAT_INTRIN

--- a/patches/gmp-fixes.patch
+++ b/patches/gmp-fixes.patch
@@ -1,0 +1,133 @@
+From 29d11e371f27b9dc6f09040215fdd49e4aa04fb5 Mon Sep 17 00:00:00 2001
+From: Maciej Lisiewski <maciej.lisiewski@gmail.com>
+Date: Thu, 15 May 2025 10:57:14 -0400
+Subject: [PATCH 1/5] Patch GMP to build on GCC15
+
+Co-authored-by: Bastien Nocera <hadess@hadess.net>
+---
+ deps/GMP/0001-GMP_GCC15.patch | 32 ++++++++++++++++++++++++++++++++
+ deps/GMP/GMP.cmake            |  5 +++--
+ 2 files changed, 35 insertions(+), 2 deletions(-)
+ create mode 100644 deps/GMP/0001-GMP_GCC15.patch
+
+diff --git a/deps/GMP/0001-GMP_GCC15.patch b/deps/GMP/0001-GMP_GCC15.patch
+new file mode 100644
+index 000000000000..e005120acdcf
+--- /dev/null
++++ b/deps/GMP/0001-GMP_GCC15.patch
+@@ -0,0 +1,32 @@
++--- GMP/acinclude.m4	2025-05-14 18:50:11.396354745 -0400
+++++ GMP/acinclude.m4.2	2025-05-14 18:57:20.757853503 -0400
++@@ -609,7 +609,7 @@
++
++ #if defined (__GNUC__) && ! defined (__cplusplus)
++ typedef unsigned long long t1;typedef t1*t2;
++-void g(){}
+++void g(int,t1 const*,t1,t2,t1 const*,int){}
++ void h(){}
++ static __inline__ t1 e(t2 rp,t2 up,int n,t1 v0)
++ {t1 c,x,r;int i;if(v0){c=1;for(i=1;i<n;i++){x=up[i];r=x+1;rp[i]=r;}}return c;}
++
++--- GMP/configure	2025-05-14 19:33:35.730593315 -0400
+++++ GMP/configure	2025-05-14 19:35:37.805619186 -0400
++@@ -6526,7 +6526,7 @@
++
++ #if defined (__GNUC__) && ! defined (__cplusplus)
++ typedef unsigned long long t1;typedef t1*t2;
++-void g(){}
+++void g(int,t1 const*,t1,t2,t1 const*,int){}
++ void h(){}
++ static __inline__ t1 e(t2 rp,t2 up,int n,t1 v0)
++ {t1 c,x,r;int i;if(v0){c=1;for(i=1;i<n;i++){x=up[i];r=x+1;rp[i]=r;}}return c;}
++@@ -8145,7 +8145,7 @@
++
++ #if defined (__GNUC__) && ! defined (__cplusplus)
++ typedef unsigned long long t1;typedef t1*t2;
++-void g(){}
+++void g(int,t1 const*,t1,t2,t1 const*,int){}
++ void h(){}
++ static __inline__ t1 e(t2 rp,t2 up,int n,t1 v0)
++ {t1 c,x,r;int i;if(v0){c=1;for(i=1;i<n;i++){x=up[i];r=x+1;rp[i]=r;}}return c;}
+diff --git a/deps/GMP/GMP.cmake b/deps/GMP/GMP.cmake
+index bc7ef4332255..12c7e77a494b 100644
+--- a/deps/GMP/GMP.cmake
++++ b/deps/GMP/GMP.cmake
+@@ -25,7 +25,7 @@ if (MSVC)
+         COMMAND ${CMAKE_COMMAND} -E copy ${_srcdir}/lib/${_gmplib} ${_dstdir}/lib/
+         COMMAND ${CMAKE_COMMAND} -E copy ${_srcdir}/lib/${_gmpdll} ${_dstdir}/bin/
+     )
+-    
++
+     add_custom_target(dep_GMP SOURCES ${_output})
+ 
+ else ()
+@@ -72,7 +72,8 @@ else ()
+         URL https://github.com/bambulab/gmp/archive/refs/tags/6.2.1.tar.gz
+         URL_HASH SHA256=705ae57ee2014b2c6fc0f572c85ee43276b99b6b256ee16c1a9d3a8c4e3609d5
+         DOWNLOAD_DIR ${DEP_DOWNLOAD_DIR}/GMP
+-        BUILD_IN_SOURCE ON 
++        PATCH_COMMAND git apply --verbose ${CMAKE_CURRENT_LIST_DIR}/0001-GMP_GCC15.patch
++        BUILD_IN_SOURCE ON
+         CONFIGURE_COMMAND  env "CFLAGS=${_gmp_ccflags}" "CXXFLAGS=${_gmp_ccflags}" ./configure ${_cross_compile_arg} --enable-shared=no --enable-cxx=yes --enable-static=yes "--prefix=${DESTDIR}/usr/local" ${_gmp_build_tgt}
+         BUILD_COMMAND     make -j
+         INSTALL_COMMAND   make install
+-- 
+2.53.0
+
+
+From f3fd7b0a6e94964e36fac2ea7b319ac78e142103 Mon Sep 17 00:00:00 2001
+From: Maciej Lisiewski <maciej.lisiewski@gmail.com>
+Date: Fri, 16 May 2025 07:49:45 -0400
+Subject: [PATCH 2/5] Update GMP PATCH_COMMAND to work without a valid git repo
+
+Co-authored-by: Bastien Nocera <hadess@hadess.net>
+---
+ deps/GMP/GMP.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/deps/GMP/GMP.cmake b/deps/GMP/GMP.cmake
+index 12c7e77a494b..e84b2ecee824 100644
+--- a/deps/GMP/GMP.cmake
++++ b/deps/GMP/GMP.cmake
+@@ -72,7 +72,7 @@ else ()
+         URL https://github.com/bambulab/gmp/archive/refs/tags/6.2.1.tar.gz
+         URL_HASH SHA256=705ae57ee2014b2c6fc0f572c85ee43276b99b6b256ee16c1a9d3a8c4e3609d5
+         DOWNLOAD_DIR ${DEP_DOWNLOAD_DIR}/GMP
+-        PATCH_COMMAND git apply --verbose ${CMAKE_CURRENT_LIST_DIR}/0001-GMP_GCC15.patch
++        PATCH_COMMAND git apply ${GMP_DIRECTORY_FLAG} --verbose ${CMAKE_CURRENT_LIST_DIR}/0001-GMP_GCC15.patch
+         BUILD_IN_SOURCE ON
+         CONFIGURE_COMMAND  env "CFLAGS=${_gmp_ccflags}" "CXXFLAGS=${_gmp_ccflags}" ./configure ${_cross_compile_arg} --enable-shared=no --enable-cxx=yes --enable-static=yes "--prefix=${DESTDIR}/usr/local" ${_gmp_build_tgt}
+         BUILD_COMMAND     make -j
+-- 
+2.53.0
+
+
+From 1e64b906f3bfb1ff55b718d8bff72d62a69bb984 Mon Sep 17 00:00:00 2001
+From: Maciej Lisiewski <maciej.lisiewski@gmail.com>
+Date: Fri, 16 May 2025 09:21:26 -0400
+Subject: [PATCH 3/5] Set GMP_DIRECTORY_FLAG
+
+Co-authored-by: Bastien Nocera <hadess@hadess.net>
+---
+ deps/GMP/GMP.cmake | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/deps/GMP/GMP.cmake b/deps/GMP/GMP.cmake
+index e84b2ecee824..d7432743c010 100644
+--- a/deps/GMP/GMP.cmake
++++ b/deps/GMP/GMP.cmake
+@@ -2,6 +2,10 @@
+ set(_srcdir ${CMAKE_CURRENT_LIST_DIR}/gmp)
+ set(_dstdir ${DESTDIR}/usr/local)
+ 
++if (IN_GIT_REPO)
++    set(GMP_DIRECTORY_FLAG --directory ${BINARY_DIR_REL}/dep_GMP-prefix/src/dep_GMP)
++endif ()
++
+ if (MSVC)
+     if ((CMAKE_SYSTEM_PROCESSOR MATCHES "^(ARM64|aarch64)$") OR (CMAKE_GENERATOR_PLATFORM STREQUAL "ARM64"))
+         set(_gmpheader win_arm64/gmp.h)
+-- 
+2.53.0
+
+


### PR DESCRIPTION
```
'runtime-is-eol-org.gnome.Platform-48' warning found in linter manifest check.
'runtime-is-eol-org.gnome.Platform-48' warning found in linter repo check.
```